### PR TITLE
ci: Fix permissions for posting comments in PRs

### DIFF
--- a/.github/workflows/check_pr_changes.yaml
+++ b/.github/workflows/check_pr_changes.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   check_changes:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3


### PR DESCRIPTION
This seems to be needed now when GITHUB_TOKEN is used.